### PR TITLE
Create .about.yml

### DIFF
--- a/.about.yml
+++ b/.about.yml
@@ -1,0 +1,20 @@
+---
+project: PeaceCorps.gov
+name: peacecorps-site
+github:
+- 18F/peacecorps-site
+description: A redesign of peacecorps.gov, offering a new, user-focused experience
+  for users.
+partners:
+- Peace Corps
+impact: 7,000 Peace Corps Volunteers in the field, hundreds of thousands Prospective/Returned
+  Volunteers, friends, and family.
+stage: beta
+contact:
+- christopher.lubinski@gsa.gov
+stack: 
+team: cm, ericronne, marco, annalee
+licenses: 
+links:
+- https://beta.peacecorps.gov
+status: 


### PR DESCRIPTION
As we scale out the [about.yml](https://github.com/18f/about_yml) standard on projects, we need to relocates the yml file for this project from [here](https://github.com/18F/data-private/blob/master/projects/peacecorps-site.yml) to the primary project repo.  

@cmc333333 - I also switched you in for Sean as contact but we can put anybody else there for that.  
